### PR TITLE
#29 - Allow app description to contain html tags

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -56,7 +56,7 @@
 					<div class="media-body">
 						<a th:href="@{/app/}+${app.name}" th:text="${app.displayName == null} ? ${app.name} : ${app.displayName}"></a>
 						<br th:if="${app.description != null}" />
-						<span th:if="${app.description != null}" th:text="${app.description}"></span>
+						<span th:if="${app.description != null}" th:utext="${app.description}"></span>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
This change allows the App description to contain html tags. WHen generating the index.html it will parse this html and render it as expected.